### PR TITLE
Fix revcom for ambiguous bases

### DIFF
--- a/temp/scripts/pickUniqPairFastq.pl
+++ b/temp/scripts/pickUniqPairFastq.pl
@@ -21,7 +21,7 @@ while(<in>)
 	## revcom the read mapped to the reverse strand
 	if($f[1]=~/r/)
 	{
-		my $seq=Bio::Seq->new(-seq=>$f[9]);
+		my $seq=Bio::Seq->new(-seq=>$f[9], -alphabet => 'dna');
 		$f[9]=$seq->revcom->seq;
 		$f[10]=reverse $f[10];
 	}

--- a/temp/scripts/pickUniqPos.pl
+++ b/temp/scripts/pickUniqPos.pl
@@ -19,7 +19,7 @@ while(<in>)
 	## revcomp
 	if($f[1]=~/r/)
         {
-                my $seq=Bio::Seq->new(-seq=>$f[9]);
+                my $seq=Bio::Seq->new(-seq=>$f[9], -alphabet => 'dna');
                 $f[9]=$seq->revcom->seq;
 		$strand="-";
         }


### PR DESCRIPTION
It is sufficient to specify the DNA alphabet.
This should fix issue #1.