### PR TITLE
Correct package version in tool_dependencies.xml

### DIFF
--- a/twobit_to_fasta/tool_dependencies.xml
+++ b/twobit_to_fasta/tool_dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="twoBitToFa" version="latest  ">
+    <package name="twoBitToFa" version="latest">
         <repository name="package_twobittofa" owner="geert-vandeweyer"/>
     </package>
 </tool_dependency>


### PR DESCRIPTION
Hi, 

I removed the extra spaces in package version.
I got an issue with installation of this tool from the main ToolShed, and I think it comes from here.

Bérénice

PS: Maybe, it could also be good to fix the version of the needed package (not "latest")